### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Sitemap/XML/Parser.pm6
+++ b/lib/Sitemap/XML/Parser.pm6
@@ -4,7 +4,7 @@ use DateTime::Format::W3CDTF;
 use LWP::Simple;
 use URI;
 
-class Sitemap::XML::Parser;
+unit class Sitemap::XML::Parser;
 
 has $!parser = XML::Parser::Tiny.new;
 has $!w3cdtf = DateTime::Format::W3CDTF.new;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.