### PR TITLE
Use kebab-case for function names

### DIFF
--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -115,7 +115,7 @@ for @changefreq_list -> $changefreq {
 my $parser = Sitemap::XML::Parser.new;
 
 for @invalid -> $sitemap {
-    dies_ok({ $parser.parse($sitemap) });
+    dies-ok({ $parser.parse($sitemap) });
 }
 
 for @valid_sitemaps Z @valid_results -> $sitemap, $struct {


### PR DESCRIPTION
Function names containing underscores have been deprecated in favour of the
kebab-case versions.  The deprecated form will be removed in the 2015.09
release of Rakudo.