### PR TITLE
Add parens to zip output used as for loop args

### DIFF
--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -118,7 +118,7 @@ for @invalid -> $sitemap {
     dies_ok({ $parser.parse($sitemap) });
 }
 
-for @valid_sitemaps Z @valid_results -> $sitemap, $struct {
+for @valid_sitemaps Z @valid_results -> ($sitemap, $struct) {
     my $rslt = $parser.parse($sitemap);
 
     for $rslt.values -> $item is rw {


### PR DESCRIPTION
The zip operator now returns an unflattened Parcel of pairs, which is not
what was expected as input to the for loop's body.  The solution is simply
to add parentheses around the arguments to the body of the for loop in order
to extract the correct data pairs of elements.  This change makes the test
suite pass again.